### PR TITLE
Do Not Crash Actor When Connection is Closed

### DIFF
--- a/lib/celluloid/websocket/client/connection.rb
+++ b/lib/celluloid/websocket/client/connection.rb
@@ -33,7 +33,11 @@ module Celluloid
           @client.start
 
           loop do
-            @client.parse(@socket.readpartial(1024))
+            begin
+              @client.parse(@socket.readpartial(1024))
+            rescue EOFError
+              break
+            end
           end
         end
 


### PR DESCRIPTION
I'm using this `WebSocketActor` (see code below) that I want to close eventually. For it to work reliably, I have to catch `EOFError` in the parsing loop. That is because the loop sometimes keeps on reading from the socket when the connection is already closed, but the `on_close` handler has not been called yet.

I'm not sure if this is the right thing to do, but I'd like to put it up for discussion.

```ruby
class WebSocketActor
  include Celluloid

  def initialize(uri)
    @client = Celluloid::WebSocket::Client.new(uri, current_actor)
  end

  def on_close(code, reason)
    @client.terminate
    terminate
  end

  def close
    @client.close
  end
end
```